### PR TITLE
replaced np.Nan with np.nan

### DIFF
--- a/gnomad_db/database.py
+++ b/gnomad_db/database.py
@@ -93,7 +93,7 @@ class gnomAD_DB:
             c.executemany(sql_input, rows)
     
     def _sanitize_variants(self, var_df: pd.DataFrame) -> pd.DataFrame:
-        var_df = var_df.replace(".", np.NaN)
+        var_df = var_df.replace(".", np.nan)
         var_df["pos"] = var_df["pos"].astype(int)
         var_df["chrom"] = var_df["chrom"].astype(str)
         var_df["chrom"] = var_df.chrom.apply(lambda x: x.replace("chr", ""))

--- a/scripts/GettingStartedwithGnomAD_DB.ipynb
+++ b/scripts/GettingStartedwithGnomAD_DB.ipynb
@@ -91,7 +91,7 @@
     "var_df = pd.read_csv(\"data/test_vcf_gnomad_chr21_10000.tsv.gz\", sep=\"\\t\", names=db.columns, index_col=False)\n",
     "# preprocess missing values\n",
     "# IMPORTANT: The database removes internally chr prefix (chr1->1)\n",
-    "var_df = var_df.replace(\".\", np.NaN)\n",
+    "var_df = var_df.replace(\".\", np.nan)\n",
     "var_df.head()"
    ]
   },

--- a/scripts/insertVariants.ipynb
+++ b/scripts/insertVariants.ipynb
@@ -69,7 +69,7 @@
     "        for line in tqdm(f):\n",
     "            line = line.decode().rstrip()\n",
     "            if len(batch) == batch_size:\n",
-    "                batch = pd.DataFrame(batch, columns=db.columns).replace(\".\", np.NaN)\n",
+    "                batch = pd.DataFrame(batch, columns=db.columns).replace(\".\", np.nan)\n",
     "                yield batch\n",
     "                batch = []\n",
     "\n",
@@ -77,7 +77,7 @@
     "        \n",
     "        \n",
     "        if len(batch) != 0:\n",
-    "            batch = pd.DataFrame(batch, columns=db.columns).replace(\".\", np.NaN)\n",
+    "            batch = pd.DataFrame(batch, columns=db.columns).replace(\".\", np.nan)\n",
     "            yield batch"
    ]
   },

--- a/test_dir/test_gnomad_db.py
+++ b/test_dir/test_gnomad_db.py
@@ -37,13 +37,13 @@ def test_get_info_from_df(database):
                                  'pos': {0: 21, 1: 9825790},
                                  'ref': {0: 'T', 1: 'C'},
                                  'alt': {0: 'G', 1: 'T'},
-                                 'AF': {0: np.NaN, 1: 0.000243902},
-                                 'AF_afr': {0: np.NaN, 1: 0.0},
-                                 'AF_eas': {0: np.NaN, 1: 0.0},
-                                 'AF_fin': {0: np.NaN, 1: 0.000959693},
-                                 'AF_nfe': {0: np.NaN, 1: 0.0},
-                                 'AF_asj': {0: np.NaN, 1: 0.0},
-                                 'AF_oth': {0: np.NaN, 1: 0.0},
+                                 'AF': {0: np.nan, 1: 0.000243902},
+                                 'AF_afr': {0: np.nan, 1: 0.0},
+                                 'AF_eas': {0: np.nan, 1: 0.0},
+                                 'AF_fin': {0: np.nan, 1: 0.000959693},
+                                 'AF_nfe': {0: np.nan, 1: 0.0},
+                                 'AF_asj': {0: np.nan, 1: 0.0},
+                                 'AF_oth': {0: np.nan, 1: 0.0},
                                  'AF_popmax': {0: None, 1: None}
     })
     
@@ -51,7 +51,7 @@ def test_get_info_from_df(database):
 
     assert expected.equals(observed[expected.columns])
     
-    expected = pd.DataFrame({'AF': {0: np.NaN, 1: 0.000243902}})
+    expected = pd.DataFrame({'AF': {0: np.nan, 1: 0.000243902}})
     
     observed = database.get_info_from_df(dummy_var_df, "AF")
     
@@ -96,7 +96,7 @@ def test_get_info_from_str(database):
 def test_insert_variants(database):
     
     dummy_var_df = pd.read_csv("data/test_vcf_gnomad_chr21_10000.tsv.gz", sep="\t", names=database.columns, index_col=False)
-    dummy_var_df = dummy_var_df.replace(".", np.NaN)
+    dummy_var_df = dummy_var_df.replace(".", np.nan)
     
     database.insert_variants(dummy_var_df)
     
@@ -113,7 +113,7 @@ def test_insert_variants(database):
 def test_query_variants_x320_000_rows(database):
     
     dummy_var_df = pd.read_csv("data/test_vcf_gnomad_chr21_10000.tsv.gz", sep="\t", names=database.columns, index_col=False)
-    dummy_var_df = dummy_var_df.replace(".", np.NaN)
+    dummy_var_df = dummy_var_df.replace(".", np.nan)
     
     dummy_var_df = pd.concat([dummy_var_df, dummy_var_df])
     #dummy_var_df = pd.concat([dummy_var_df, dummy_var_df])
@@ -180,7 +180,7 @@ def test_get_interval_from_str(database):
                              'AF_nfe': {0: 0.00145879, 1: 0.00109409, 2: 0.0, 3: 0.0, 4: 0.00126263},
                              'AF_asj': {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0},
                              'AF_oth': {0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0},
-                             'AF_popmax': {0: 0.00145879, 1: 0.00109409, 2: np.NaN, 3: np.NaN, 4: 0.00126263}})
+                             'AF_popmax': {0: 0.00145879, 1: 0.00109409, 2: np.nan, 3: np.nan, 4: 0.00126263}})
     
     observed = database.get_info_for_interval(chrom=21, interval_start=9825787, interval_end=9825793, query="*")
     


### PR DESCRIPTION
First of all, thank you very much for the amazing workflow and clear documentation! 
I was already dreading doing the processing of the WGS gnomAD VCFs myself...

With that being said, the current setup causes the `snakemake` pipeline to fail in step 2, because recent versions of numpy do not support `np.Nan` anymore. See the release notes here: https://numpy.org/doc/stable/release/2.0.0-notes.html.

The fix is to simply replace `np.Nan` with `np.nan` and everything runs smoothly. 
